### PR TITLE
Enable developer to select instance type for node creation

### DIFF
--- a/andaime.go
+++ b/andaime.go
@@ -73,6 +73,7 @@ var (
 	COMPUTE_INSTANCE_TYPE              string
 	ORCHESTRATOR_INSTANCE_TYPE         string
 	VALID_ARCHITECTURES =              []string{"arm64", "x86_64"}
+	BOOT_VOLUME_SIZE_FLAG              int
 )
 
 func getUbuntuAMIId(svc *ec2.EC2, arch string) (string, error) {
@@ -659,7 +660,7 @@ func createInstanceInRegion(svc *ec2.EC2, region string, nodeType string, orches
 		}
 		encodedUserData := base64.StdEncoding.EncodeToString([]byte(userData))
 
-		bootVolumeSize := int64(50) // Example: 50 GiB
+		bootVolumeSize := int64(BOOT_VOLUME_SIZE_FLAG) // Example: 50 GiB
 
 		// Create EC2 Instance
 		runResult, err := svc.RunInstances(&ec2.RunInstancesInput{
@@ -1613,6 +1614,7 @@ func main() {
 	flag.StringVar(&INSTANCE_TYPE, "instance-type", "t2.medium", "The instance type for both the compute and orchestrator nodes")
 	flag.StringVar(&COMPUTE_INSTANCE_TYPE, "compute-instance-type", "", "The instance type for the compute nodes. Overrides --instance-type for compute nodes.")
 	flag.StringVar(&ORCHESTRATOR_INSTANCE_TYPE, "orchestrator-instance-type", "", "The instance type for the orchestrator nodes. Overrides --instance-type for orchestrator nodes.")
+	flag.IntVar(&BOOT_VOLUME_SIZE_FLAG, "volume-size", 8, "The volume size of each node created (Gigabytes). Default: 8")
 	flag.BoolVar(&helpFlag, "help", false, "Show help message")
 
 	flag.Parse()


### PR DESCRIPTION
Previously, all instances created with Andaime were `t2.medium` type instances.

Now, with the `--compute-instance-type` and `--orchestrator-instance-type` flags, users can pass through the instance type they would like their compute/orchestrator nodes to be.

With the usage if these flags, Andaime will also lookup the corresponding architecture type and AMI for Ubuntu 22.04 to spin up the instances.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
    - Added new instance types: `INSTANCE_TYPE`, `COMPUTE_INSTANCE_TYPE`, and `ORCHESTRATOR_INSTANCE_TYPE`.
    - Introduced `VALID_ARCHITECTURES` slice with values "arm64" and "x86_64".
    - Enhanced AMI selection logic based on architecture and error handling.
    - Improved instance type selection based on node type.
    - Included boot volume size configuration for EC2 instances creation.
    - Updated flag definitions for `INSTANCE_TYPE`, `COMPUTE_INSTANCE_TYPE`, `ORCHESTRATOR_INSTANCE_TYPE`, and `BOOT_VOLUME_SIZE_FLAG`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->